### PR TITLE
docs: add guide for a local deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 
 This repository contains the documentation framework for providing the documentation files of all EDC
 repositories as a [GitHub page](https://docs.github.com/en/pages).
-**The pages are deployed at <https://eclipse-dataspaceconnector.github.io/docs>.**
+
+The pages are deployed from the `/docs` sub-directory to <https://eclipse-dataspaceconnector.github.io/docs>.
+
+## Local Deployment
+
+If you want to add content or change configurations, please refer to the [official Docsify documentation](https://docsify.js.org/).
+
+For a local deployment, install [Node.js](https://nodejs.org/), check out this repository, and run Docsify:
+```commandline
+$ git clone https://github.com/eclipse-dataspaceconnector/docs.git
+$ cd docs
+$ npm i docsify-cli -g
+$ docsify serve docs
+```
 
 ## Contributing
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a section to the main `README`.

## Why it does that

Provide information about a local deployment.

## Further notes

--

## Linked Issue(s)

Closes #9 

## Checklist

- [ ] added/updated copyright headers?
- [ ] documented code?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
