### PR TITLE
docs(hands on): add link to build/run a connector

### DIFF
--- a/docs/hands-on.md
+++ b/docs/hands-on.md
@@ -1,5 +1,6 @@
 # Hands-on
 
+- [Build and run a monolithic connector](submodule/Connector/docs/developer/build-your-own-connector.md)
 - [Connector Samples](submodule/Connector/samples/)
 - [Minimum Viable Dataspace](submodule/MinimumViableDataspace/)
 - [Open API Specification](https://eclipse-dataspaceconnector.github.io/docs/submodule/Connector/docs/swaggerui/index.html)


### PR DESCRIPTION
## What this PR changes/adds

Links to a document provided in the connector repo.

## Why it does that

Help with understanding this project

## Further notes

In the long term, this "hands on" section should provide detailed information about how to build, use and extend data space components as described [here](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/pull/2061#issuecomment-1271613575). 

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added/updated copyright headers?
- [ ] documented code?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
