### PR TITLE
chore: add GradlePlugins repository as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "docs/submodule/RegistrationService"]
 	path = docs/submodule/RegistrationService
 	url = https://github.com/eclipse-dataspaceconnector/RegistrationService.git
+[submodule "docs/submodule/GradlePlugins"]
+	path = docs/submodule/GradlePlugins
+	url = https://github.com/eclipse-dataspaceconnector/GradlePlugins.git

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -16,6 +16,7 @@ and https://github.com/docsifyjs/docsify/issues/1139)
   - <a href="#/submodule/Connector/">Connector</a>
   - <a href="#/submodule/DataDashboard/">Data Dashboard</a>
   - <a href="#/submodule/FederatedCatalog/">Federated Catalog</a>
+  - <a href="#/submodule/GradlePlugins/">Gradle Plugins</a>
   - <a href="#/submodule/IdentityHub/">Identity Hub</a>
   - <a href="#/submodule/MinimumViableDataspace/">Minimum Viable Dataspace</a>
   - <a href="#/submodule/RegistrationService/">Registration Service</a>


### PR DESCRIPTION
## What this PR changes/adds

Adds https://github.com/eclipse-dataspaceconnector/GradlePlugins as submodule and links it in menu bar.

## Why it does that

Include new EDC repo in GitHub pages.

## Further notes

--

## Linked Issue(s)

Closes #8

## Checklist

- [ ] added/updated copyright headers?
- [ ] documented code?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
