### PR TITLE
chore(module): add Trust Framework Adoption repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "docs/submodule/GradlePlugins"]
 	path = docs/submodule/GradlePlugins
 	url = https://github.com/eclipse-dataspaceconnector/GradlePlugins.git
+[submodule "docs/submodule/TrustFrameworkAdoption"]
+	path = docs/submodule/TrustFrameworkAdoption
+	url = https://github.com/eclipse-dataspaceconnector/TrustFrameworkAdoption

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -20,6 +20,7 @@ and https://github.com/docsifyjs/docsify/issues/1139)
   - <a href="#/submodule/IdentityHub/">Identity Hub</a>
   - <a href="#/submodule/MinimumViableDataspace/">Minimum Viable Dataspace</a>
   - <a href="#/submodule/RegistrationService/">Registration Service</a>
+  - <a href="#/submodule/TrustFrameworkAdoption/">Trust Framework Adoption</a>
 
 - Documents
   - <a href="#/submodule/Collateral/">Collateral</a>


### PR DESCRIPTION
## What this PR changes/adds

Adds https://github.com/eclipse-dataspaceconnector/TrustFrameworkAdoption as submodule and links it in menu bar.

## Why it does that

Include new EDC repo in GitHub pages.

## Further notes

--

## Linked Issue(s)

Closes #16 

## Checklist

- [ ] added/updated copyright headers?
- [ ] documented code?
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) for details_)
